### PR TITLE
feat: switch to using the /oauth2 provider

### DIFF
--- a/app/lib/client.ts
+++ b/app/lib/client.ts
@@ -4,9 +4,9 @@ export async function setUpOIDC() {
   let tenantURL = process.env.TENANT_URL;
 
   if(tenantURL?.endsWith('/')) {
-    tenantURL = `${tenantURL}oidc/endpoint/default/.well-known/openid-configuration`
+    tenantURL = `${tenantURL}oauth2/.well-known/openid-configuration`
   } else {
-    tenantURL = `${tenantURL}/oidc/endpoint/default/.well-known/openid-configuration`
+    tenantURL = `${tenantURL}/oauth2/.well-known/openid-configuration`
   }
   const issuer = await Issuer.discover(tenantURL);
   return new issuer.Client({


### PR DESCRIPTION
Verify supports two OIDC providers. This change modifies the example to use the new endpoints.

NOTE: Applications created using the custom connector template will work with both endpoints. /oauth2 offers addtional capabilities that are visible in the OpenID Connect application connector.